### PR TITLE
chore(composer): auto-create phapi-llms.txt on Composer install/update and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,43 @@ Config:
 ],
 ```
 
+## ORM (MySQL via Hyperf)
+
+Requires a coroutine context, `ext-pdo_mysql`, and the Hyperf DB packages:
+
+```bash
+composer require hyperf/db-connection hyperf/database hyperf/config
+```
+
+Register the provider and use the PHAPI database service or base model:
+
+```php
+use PHAPI\PHAPI;
+use PHAPI\Providers\OrmMysqlProvider;
+use PHAPI\Database\PhapiModel;
+
+$api = new PHAPI([
+    'providers' => [OrmMysqlProvider::class],
+    'orm' => [
+        'mysql' => [
+            'database' => 'app',
+            'username' => 'root',
+            'password' => '',
+        ],
+    ],
+]);
+
+$users = $api->database()->table('users')->where('active', 1)->get();
+
+final class User extends PhapiModel
+{
+    protected ?string $table = 'users';
+}
+```
+
+If `orm.mysql` is missing, PHAPI derives it from the existing `mysql` block for compatibility.
+See `docs/database-orm-mysql.md` for full configuration and usage notes.
+
 ## Error Responses
 
 `Response::error()` returns a JSON payload with `error` plus any extra fields you pass.
@@ -637,6 +674,12 @@ $api = new PHAPI([
     },
 ]);
 ```
+
+## LLM guide file
+
+When installing PHAPI via Composer, a `phapi-llms.txt` file is created in the project
+root (if it does not already exist). This file is a model-friendly reference that mirrors
+the `llms.txt` shipped in the repository for quick AI tooling context.
 
 ## Example Structure
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     "require": {
         "php": "^8.0",
         "ext-swoole": "*",
+        "hyperf/config": "^3.1",
+        "hyperf/database": "^3.1",
+        "hyperf/db-connection": "^3.1",
         "psr/container": "^2.0"
     },
     "require-dev": {
@@ -63,7 +66,13 @@
         "lint": "php-cs-fixer fix --dry-run --diff",
         "lint:fix": "php-cs-fixer fix",
         "phpunit": "phpunit",
-        "phpstan": "PHPSTAN_DISABLE_PARALLEL=1 php vendor/bin/phpstan analyse -c phpstan.neon --no-progress"
+        "phpstan": "PHPSTAN_DISABLE_PARALLEL=1 php vendor/bin/phpstan analyse -c phpstan.neon --no-progress",
+        "post-install-cmd": [
+            "@php -r \"\$source=__DIR__.'/llms.txt'; \$target=getcwd().'/phapi-llms.txt'; if (file_exists(\$source) && !file_exists(\$target)) { copy(\$source, \$target); }\""
+        ],
+        "post-update-cmd": [
+            "@php -r \"\$source=__DIR__.'/llms.txt'; \$target=getcwd().'/phapi-llms.txt'; if (file_exists(\$source) && !file_exists(\$target)) { copy(\$source, \$target); }\""
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/config/phapi.php
+++ b/config/phapi.php
@@ -36,4 +36,28 @@ return [
         'pool_size' => 5,
         'pool_timeout' => 1.0,
     ],
+    'orm' => [
+        'mysql' => [
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => '',
+            'username' => '',
+            'password' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => false,
+                PDO::ATTR_STRINGIFY_FETCHES => false,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 50,
+                'connect_timeout' => 10.0,
+                'wait_timeout' => 3.0,
+                'max_idle_time' => 60.0,
+            ],
+            'log_queries' => false,
+        ],
+    ],
 ];

--- a/docs/database-orm-mysql.md
+++ b/docs/database-orm-mysql.md
@@ -1,0 +1,130 @@
+# MySQL ORM (Hyperc DB stack)
+
+PHAPI ships an optional MySQL ORM integration based on Hyperf's database stack. It provides
+query builder access via `$api->database()` or `PHAPI::db()` and an Eloquent-style base
+model via `PHAPI\Database\PhapiModel`.
+
+## Install
+
+```bash
+composer require hyperf/db-connection hyperf/database hyperf/config
+```
+
+Requirements:
+
+- PHP `ext-pdo_mysql`
+- Swoole runtime (native or portable)
+- Coroutine hooks enabled (`enable_coroutine_hooks` = true)
+
+## Configuration
+
+Enable the provider and supply `orm.mysql` config:
+
+```php
+use PHAPI\PHAPI;
+use PHAPI\Providers\OrmMysqlProvider;
+
+$api = new PHAPI([
+    'providers' => [OrmMysqlProvider::class],
+    'orm' => [
+        'mysql' => [
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => 'app',
+            'username' => 'root',
+            'password' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => false,
+                PDO::ATTR_STRINGIFY_FETCHES => false,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 50,
+                'connect_timeout' => 10.0,
+                'wait_timeout' => 3.0,
+                'max_idle_time' => 60.0,
+            ],
+            'log_queries' => false,
+        ],
+    ],
+]);
+```
+
+### Compatibility aliasing
+
+If `orm.mysql` is not set, PHAPI derives it from the existing `mysql` config block:
+
+- `mysql.host` → `orm.mysql.host`
+- `mysql.port` → `orm.mysql.port`
+- `mysql.user` → `orm.mysql.username`
+- `mysql.password` → `orm.mysql.password`
+- `mysql.database` → `orm.mysql.database`
+- `mysql.charset` → `orm.mysql.charset`
+- `mysql.timeout` → `orm.mysql.pool.connect_timeout`
+- `mysql.pool_size` → `orm.mysql.pool.min_connections` + `max_connections`
+- `mysql.pool_timeout` → `orm.mysql.pool.wait_timeout`
+
+## Usage
+
+### Query builder
+
+```php
+$users = $api->database()->table('users')
+    ->where('active', 1)
+    ->orderByDesc('id')
+    ->get();
+```
+
+### Models
+
+```php
+use PHAPI\Database\PhapiModel;
+
+final class User extends PhapiModel
+{
+    protected ?string $table = 'users';
+}
+
+$active = User::query()->where('active', 1)->get();
+```
+
+### Transactions
+
+```php
+$api->database()->transaction(function () use ($api) {
+    $api->database()->statement('UPDATE wallets SET balance = balance - 1 WHERE id = ?', [1]);
+    $api->database()->statement('UPDATE wallets SET balance = balance + 1 WHERE id = ?', [2]);
+});
+```
+
+## Parallelism
+
+Use the task runner or jobs to execute database work in parallel coroutines:
+
+```php
+$results = $api->tasks()->parallel([
+    fn () => $api->database()->table('users')->count(),
+    fn () => $api->database()->table('orders')->count(),
+]);
+```
+
+## Pitfalls
+
+- Pool sizing matters for long-running workloads. Ensure `max_connections` matches expected
+  concurrency to avoid pool wait timeouts.
+- Coroutine hooks must be enabled for non-blocking PDO I/O. PHAPI logs a warning when
+  `enable_coroutine_hooks` is `false`.
+- Query logging depends on the Hyperf connection `listen()` hook. If unavailable, PHAPI logs
+  a warning and skips logging.
+- Long-running workers should avoid holding onto model instances across requests.
+
+## Troubleshooting
+
+| Issue | Guidance |
+| --- | --- |
+| Pool wait timeout | Increase `orm.mysql.pool.wait_timeout` or `max_connections`. |
+| Hooks disabled warning | Set `enable_coroutine_hooks` to `true` in config. |
+| Connection errors | Verify credentials, host/port, and that `ext-pdo_mysql` is enabled. |

--- a/examples/orm-mysql/app.php
+++ b/examples/orm-mysql/app.php
@@ -1,0 +1,50 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use PHAPI\Database\PhapiModel;
+use PHAPI\HTTP\Response;
+use PHAPI\PHAPI;
+use PHAPI\Providers\OrmMysqlProvider;
+
+final class User extends PhapiModel
+{
+    protected ?string $table = 'users';
+}
+
+$api = new PHAPI([
+    'runtime' => getenv('APP_RUNTIME') ?: 'swoole',
+    'host' => '0.0.0.0',
+    'port' => 9504,
+    'debug' => true,
+    'providers' => [OrmMysqlProvider::class],
+    'orm' => [
+        'mysql' => [
+            'host' => getenv('MYSQL_HOST') ?: '127.0.0.1',
+            'port' => (int)(getenv('MYSQL_PORT') ?: 3306),
+            'database' => getenv('MYSQL_DATABASE') ?: 'app',
+            'username' => getenv('MYSQL_USER') ?: 'root',
+            'password' => getenv('MYSQL_PASSWORD') ?: '',
+        ],
+    ],
+]);
+
+$api->get('/users', function () use ($api): Response {
+    $users = $api->database()->table('users')->limit(10)->get();
+    return Response::json(['users' => $users]);
+});
+
+$api->get('/users/model', function (): Response {
+    $users = User::query()->limit(10)->get();
+    return Response::json(['users' => $users]);
+});
+
+$api->get('/tx', function () use ($api): Response {
+    $api->database()->transaction(function () use ($api): void {
+        $api->database()->statement('UPDATE widgets SET counter = counter + 1 WHERE id = ?', [1]);
+    });
+
+    return Response::json(['ok' => true]);
+});
+
+$api->run();

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,352 @@
+# PHAPI LLM Guide
+
+This document is a concise reference for PHAPI. It summarizes the framework structure,
+configuration, runtime behavior, and provides runnable examples for common features
+including routing, middleware, validation, jobs, tasks, realtime, Redis, MySQL, and
+the Hyperf-based ORM integration.
+
+## Project layout
+
+- `src/`: core runtime, HTTP stack, services, contracts.
+- `tests/`: PHPUnit tests (unit + integration).
+- `examples/`: runnable examples (single-file, multi-file, example app).
+- `config/`: default config (`config/phapi.php`).
+- `docs/`: staged implementation notes and supporting docs.
+- `bin/`: CLI helpers (`phapi-run`, `phapi-jobs`).
+
+## Runtime overview
+
+PHAPI is a lightweight API framework for Swoole with:
+
+- Routing and middleware
+- Request validation
+- Jobs + async tasks
+- Realtime via WebSockets
+- Redis + MySQL (PDO coroutine) clients
+- Optional Hyperf ORM integration
+
+Coroutine hooks are enabled by default (`enable_coroutine_hooks`). For Swoole, this
+allows blocking I/O (PDO, Redis) to yield cooperatively.
+
+## Basic app
+
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use PHAPI\PHAPI;
+use PHAPI\HTTP\Response;
+
+$api = new PHAPI([
+    'runtime' => getenv('APP_RUNTIME') ?: 'swoole',
+    'host' => '0.0.0.0',
+    'port' => 9501,
+    'debug' => true,
+]);
+
+$api->get('/', fn () => Response::json(['message' => 'Hello from PHAPI']));
+
+$api->run();
+```
+
+## Routing + params
+
+```php
+$api->get('/users/{id}', function (): Response {
+    $request = PHAPI::request();
+    return Response::json(['user_id' => $request?->param('id')]);
+})->name('users.show');
+```
+
+URL generation:
+
+```php
+$url = $api->url('users.show', ['id' => 42]);
+```
+
+## Middleware
+
+Global:
+
+```php
+$api->middleware(function ($request, $next) {
+    return $next($request);
+});
+```
+
+Named:
+
+```php
+$api->addMiddleware('role:admin', function ($request, $next) {
+    return $next($request);
+});
+```
+
+Per-route:
+
+```php
+$api->get('/admin', fn () => Response::json(['ok' => true]))
+    ->middleware('role:admin');
+```
+
+## Validation
+
+```php
+$api->post('/users', fn () => Response::json(['created' => true], 201))
+    ->validate([
+        'name' => 'required|string|min:2',
+        'email' => 'required|email',
+    ]);
+```
+
+## Auth helpers
+
+```php
+$api->get('/protected', fn () => Response::json(['ok' => true]))
+    ->middleware($api->requireAuth());
+```
+
+Role checks:
+
+```php
+$api->get('/admin', fn () => Response::json(['ok' => true]))
+    ->middleware($api->requireRole('admin'));
+```
+
+## Jobs
+
+```php
+$api->schedule('cleanup', 300, function () {
+    echo "cleanup executed";
+}, [
+    'log_enabled' => true,
+    'lock_mode' => 'skip',
+]);
+```
+
+Run due jobs from CLI:
+
+```bash
+PHAPI_RUN_MODE=jobs php example.php
+```
+
+## Tasks (parallel work)
+
+```php
+$results = $api->tasks()->parallel([
+    fn () => 1 + 1,
+    fn () => 2 + 2,
+]);
+```
+
+## Realtime (WebSockets)
+
+```php
+$api->realtime()->broadcast('channel', ['event' => 'ping']);
+```
+
+Custom WS handler:
+
+```php
+$api->setWebSocketHandler(function ($server, $frame, $driver) {
+    $data = json_decode($frame->data ?? '', true);
+    if (!is_array($data)) {
+        return;
+    }
+    if (($data['action'] ?? '') === 'subscribe' && !empty($data['channel'])) {
+        $driver->subscribe($frame->fd, $data['channel']);
+    }
+});
+```
+
+## Redis (Swoole coroutine)
+
+```php
+$redis = $api->redis();
+$redis->set('greeting', 'hello', 30);
+$value = $redis->get('greeting');
+```
+
+Config (defaults in `config/phapi.php`):
+
+```php
+'redis' => [
+    'host' => '127.0.0.1',
+    'port' => 6379,
+    'auth' => null,
+    'db' => null,
+    'timeout' => 1.0,
+],
+```
+
+## MySQL (PDO + coroutine hooks)
+
+```php
+$mysql = $api->mysql();
+$rows = $mysql->query('SELECT 1 AS ok');
+$mysql->execute('INSERT INTO users(name) VALUES (?)', ['Ada']);
+```
+
+Config:
+
+```php
+'mysql' => [
+    'host' => '127.0.0.1',
+    'port' => 3306,
+    'user' => 'root',
+    'password' => '',
+    'database' => '',
+    'charset' => 'utf8mb4',
+    'timeout' => 1.0,
+    'pool_size' => 5,
+    'pool_timeout' => 1.0,
+],
+```
+
+## ORM (Hyperc DB stack)
+
+Install dependencies:
+
+```bash
+composer require hyperf/db-connection hyperf/database hyperf/config
+```
+
+Enable the provider and configure `orm.mysql`:
+
+```php
+use PHAPI\Providers\OrmMysqlProvider;
+
+$api = new PHAPI([
+    'providers' => [OrmMysqlProvider::class],
+    'orm' => [
+        'mysql' => [
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => 'app',
+            'username' => 'root',
+            'password' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                PDO::ATTR_EMULATE_PREPARES => false,
+                PDO::ATTR_STRINGIFY_FETCHES => false,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 50,
+                'connect_timeout' => 10.0,
+                'wait_timeout' => 3.0,
+                'max_idle_time' => 60.0,
+            ],
+            'log_queries' => false,
+        ],
+    ],
+]);
+```
+
+If `orm.mysql` is missing, PHAPI derives it from the existing `mysql` config block.
+
+Query builder:
+
+```php
+$users = $api->database()->table('users')
+    ->where('active', 1)
+    ->orderByDesc('id')
+    ->get();
+```
+
+Models:
+
+```php
+use PHAPI\Database\PhapiModel;
+
+final class User extends PhapiModel
+{
+    protected ?string $table = 'users';
+}
+
+$active = User::query()->where('active', 1)->get();
+```
+
+Transactions:
+
+```php
+$api->database()->transaction(function () use ($api) {
+    $api->database()->statement('UPDATE wallets SET balance = balance - 1 WHERE id = ?', [1]);
+    $api->database()->statement('UPDATE wallets SET balance = balance + 1 WHERE id = ?', [2]);
+});
+```
+
+Parallel DB work:
+
+```php
+$results = $api->tasks()->parallel([
+    fn () => $api->database()->table('users')->count(),
+    fn () => $api->database()->table('orders')->count(),
+]);
+```
+
+Query logging: set `orm.mysql.log_queries = true`. If the connection does not
+support `listen()`, PHAPI logs a warning and skips logging.
+
+## Error responses
+
+```php
+return Response::error('Not found', 404, ['resource' => 'user']);
+```
+
+## Security headers
+
+```php
+$api->enableSecurityHeaders([
+    'X-Frame-Options' => 'DENY',
+]);
+```
+
+## CORS
+
+```php
+$api->enableCORS('*');
+```
+
+## Access logging
+
+```php
+$api = new PHAPI([
+    'access_logger' => function ($request, $response, array $meta) {
+        error_log(json_encode([
+            'method' => $request->method(),
+            'path' => $request->path(),
+            'status' => $response->status(),
+            'request_id' => $meta['request_id'],
+            'duration_ms' => $meta['duration_ms'],
+        ]));
+    },
+]);
+```
+
+## Testing
+
+- `composer test`: full PHPUnit suite with testdox output.
+- `composer test:integration`: integration-only.
+- `composer phpstan`: static analysis.
+- `composer lint`: PHP-CS-Fixer dry-run.
+
+## Runtime selection
+
+Set `APP_RUNTIME` to choose runtime:
+
+```bash
+APP_RUNTIME=swoole php example.php
+APP_RUNTIME=portable_swoole php bin/phapi-run example.php
+```
+
+---
+
+For more detail, see:
+
+- `README.md`
+- `docs/database-orm-mysql.md`
+- `docs/project-structure.md`

--- a/src/Contracts/DatabaseInterface.php
+++ b/src/Contracts/DatabaseInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Contracts;
+
+interface DatabaseInterface
+{
+    /**
+     * @param string $table
+     * @return object
+     */
+    public function table(string $table): object;
+
+    /**
+     * @param string $sql
+     * @param array<int, mixed> $bindings
+     * @return array<int, array<string, mixed>>
+     */
+    public function select(string $sql, array $bindings = []): array;
+
+    /**
+     * @param string $sql
+     * @param array<int, mixed> $bindings
+     * @return bool
+     */
+    public function statement(string $sql, array $bindings = []): bool;
+
+    /**
+     * @param callable(): mixed $fn
+     * @return mixed
+     */
+    public function transaction(callable $fn);
+
+    /**
+     * @return object
+     */
+    public function connection(): object;
+}

--- a/src/Database/PhapiModel.php
+++ b/src/Database/PhapiModel.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Database;
+
+use Hyperf\DbConnection\Model\Model;
+
+abstract class PhapiModel extends Model
+{
+    /**
+     * @var array<int, string>
+     */
+    protected array $guarded = [];
+
+    public bool $timestamps = true;
+}

--- a/src/Exceptions/ConfigException.php
+++ b/src/Exceptions/ConfigException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Exceptions;
+
+final class ConfigException extends PhapiException
+{
+    protected int $httpStatusCode = 500;
+}

--- a/src/Exceptions/DatabaseException.php
+++ b/src/Exceptions/DatabaseException.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Exceptions;
+
+final class DatabaseException extends PhapiException
+{
+    protected int $httpStatusCode = 500;
+    private ?string $sql;
+    /**
+     * @var array<int, mixed>
+     */
+    private array $bindings;
+
+    /**
+     * @param string $message
+     * @param \Throwable|null $previous
+     * @param string|null $sql
+     * @param array<int, mixed> $bindings
+     */
+    public function __construct(
+        string $message,
+        ?\Throwable $previous = null,
+        ?string $sql = null,
+        array $bindings = []
+    ) {
+        parent::__construct($message, 0, $previous);
+        $this->sql = $sql;
+        $this->bindings = $bindings;
+    }
+
+    public function sql(): ?string
+    {
+        return $this->sql;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function bindings(): array
+    {
+        return $this->bindings;
+    }
+}

--- a/src/PHAPI.php
+++ b/src/PHAPI.php
@@ -15,6 +15,7 @@ use PHAPI\Core\HttpKernelFactory;
 use PHAPI\Core\JobsScheduler;
 use PHAPI\Core\ProviderLoader;
 use PHAPI\Core\RuntimeManager;
+use PHAPI\Contracts\DatabaseInterface;
 use PHAPI\Exceptions\FeatureNotSupportedException;
 use PHAPI\HTTP\Request;
 use PHAPI\HTTP\RequestContext;
@@ -339,6 +340,16 @@ final class PHAPI
     public function container(): Container
     {
         return $this->container;
+    }
+
+    /**
+     * Access the loaded configuration.
+     *
+     * @return array<string, mixed>
+     */
+    public function config(): array
+    {
+        return $this->config;
     }
 
     /**
@@ -868,6 +879,26 @@ final class PHAPI
         }
 
         return $this->redisClient;
+    }
+
+    /**
+     * Get the ORM database service.
+     *
+     * @return DatabaseInterface
+     */
+    public function database(): DatabaseInterface
+    {
+        return $this->container->get(DatabaseInterface::class);
+    }
+
+    /**
+     * Access the PHAPI database service, if registered.
+     *
+     * @return DatabaseInterface|null
+     */
+    public static function db(): ?DatabaseInterface
+    {
+        return static::app()?->database();
     }
 
     /**

--- a/src/Providers/OrmMysqlProvider.php
+++ b/src/Providers/OrmMysqlProvider.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Providers;
+
+use Hyperf\Config\Config;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\DbConnection\ConnectionFactory;
+use Hyperf\DbConnection\ConnectionResolver;
+use Hyperf\DbConnection\Pool\PoolFactory;
+use Hyperf\Database\Model\Model;
+use PHAPI\Contracts\DatabaseInterface;
+use PHAPI\Core\Container;
+use PHAPI\Core\ServiceProviderInterface;
+use PHAPI\Exceptions\ConfigException;
+use PHAPI\PHAPI;
+use PHAPI\Services\Database;
+
+final class OrmMysqlProvider implements ServiceProviderInterface
+{
+    public function register(Container $container, PHAPI $app): void
+    {
+        $config = $app->config();
+        $ormConfig = $this->resolveOrmMysqlConfig($config);
+        $this->validateOrmMysqlConfig($ormConfig);
+
+        $hyperfConfig = $this->buildHyperfConfig($ormConfig);
+
+        $container->singleton(ConfigInterface::class, static function () use ($hyperfConfig) {
+            return new Config($hyperfConfig);
+        });
+
+        $container->singleton(PoolFactory::class, static function (Container $container) {
+            return new PoolFactory($container);
+        });
+
+        $container->singleton(ConnectionFactory::class, static function (Container $container) {
+            return new ConnectionFactory($container);
+        });
+
+        $container->singleton(ConnectionResolver::class, static function (Container $container) {
+            return new ConnectionResolver($container);
+        });
+
+        $container->singleton(DatabaseInterface::class, static function (Container $container) use ($config) {
+            $resolver = $container->get(ConnectionResolver::class);
+            return new Database($resolver, (bool)($config['debug'] ?? false));
+        });
+
+        if (($config['enable_coroutine_hooks'] ?? true) === false) {
+            error_log('PHAPI ORM MySQL requires coroutine hooks for async I/O; enable_coroutine_hooks is false.');
+        }
+    }
+
+    public function boot(PHAPI $app): void
+    {
+        $resolver = $app->container()->get(ConnectionResolver::class);
+        Model::setConnectionResolver($resolver);
+        $config = $app->config();
+        $ormConfig = $this->resolveOrmMysqlConfig($config);
+        if (($ormConfig['log_queries'] ?? false) === true) {
+            $this->attachQueryLogger($resolver);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    private function resolveOrmMysqlConfig(array $config): array
+    {
+        $defaults = $this->defaultOrmMysqlConfig();
+        /** @var array<string, mixed>|null $orm */
+        $orm = $config['orm']['mysql'] ?? null;
+
+        if ($orm === null) {
+            /** @var array<string, mixed> $mysql */
+            $mysql = $config['mysql'] ?? [];
+            $poolSize = isset($mysql['pool_size']) ? (int)$mysql['pool_size'] : (int)$defaults['pool']['max_connections'];
+            $poolTimeout = $mysql['pool_timeout'] ?? $defaults['pool']['wait_timeout'];
+            $connectTimeout = $mysql['timeout'] ?? $defaults['pool']['connect_timeout'];
+
+            return [
+                'host' => $mysql['host'] ?? $defaults['host'],
+                'port' => $mysql['port'] ?? $defaults['port'],
+                'database' => $mysql['database'] ?? $defaults['database'],
+                'username' => $mysql['user'] ?? $defaults['username'],
+                'password' => $mysql['password'] ?? $defaults['password'],
+                'charset' => $mysql['charset'] ?? $defaults['charset'],
+                'collation' => $defaults['collation'],
+                'prefix' => $defaults['prefix'],
+                'options' => $defaults['options'],
+                'pool' => [
+                    'min_connections' => max(1, $poolSize),
+                    'max_connections' => max(1, $poolSize),
+                    'connect_timeout' => (float)$connectTimeout,
+                    'wait_timeout' => (float)$poolTimeout,
+                    'max_idle_time' => (float)$defaults['pool']['max_idle_time'],
+                ],
+                'log_queries' => $defaults['log_queries'],
+            ];
+        }
+
+        return array_replace_recursive($defaults, $orm);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function defaultOrmMysqlConfig(): array
+    {
+        return [
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'database' => '',
+            'username' => '',
+            'password' => '',
+            'charset' => 'utf8mb4',
+            'collation' => 'utf8mb4_unicode_ci',
+            'prefix' => '',
+            'options' => [
+                \PDO::ATTR_EMULATE_PREPARES => false,
+                \PDO::ATTR_STRINGIFY_FETCHES => false,
+            ],
+            'pool' => [
+                'min_connections' => 2,
+                'max_connections' => 50,
+                'connect_timeout' => 10.0,
+                'wait_timeout' => 3.0,
+                'max_idle_time' => 60.0,
+            ],
+            'log_queries' => false,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $ormConfig
+     * @return void
+     */
+    private function validateOrmMysqlConfig(array $ormConfig): void
+    {
+        $database = trim((string)($ormConfig['database'] ?? ''));
+        if ($database === '') {
+            throw new ConfigException('PHAPI ORM MySQL config requires a database name.');
+        }
+
+        $username = trim((string)($ormConfig['username'] ?? ''));
+        if ($username === '') {
+            throw new ConfigException('PHAPI ORM MySQL config requires a username.');
+        }
+
+        $host = trim((string)($ormConfig['host'] ?? ''));
+        if ($host === '') {
+            throw new ConfigException('PHAPI ORM MySQL config requires a host.');
+        }
+
+        $pool = $ormConfig['pool'] ?? [];
+        $min = $pool['min_connections'] ?? null;
+        $max = $pool['max_connections'] ?? null;
+        if (!is_numeric($min) || !is_numeric($max)) {
+            throw new ConfigException('PHAPI ORM MySQL pool config requires numeric min_connections and max_connections.');
+        }
+
+        $minValue = (int)$min;
+        $maxValue = (int)$max;
+        if ($minValue < 1 || $maxValue < 1 || $maxValue < $minValue) {
+            throw new ConfigException('PHAPI ORM MySQL pool config must satisfy max_connections >= min_connections >= 1.');
+        }
+
+        foreach (['connect_timeout', 'wait_timeout', 'max_idle_time'] as $key) {
+            $value = $pool[$key] ?? null;
+            if ($value === null || !is_numeric($value)) {
+                throw new ConfigException("PHAPI ORM MySQL pool config requires numeric {$key}.");
+            }
+        }
+
+        $options = $ormConfig['options'] ?? null;
+        if ($options !== null && !is_array($options)) {
+            throw new ConfigException('PHAPI ORM MySQL options must be an array.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $ormConfig
+     * @return array<string, mixed>
+     */
+    private function buildHyperfConfig(array $ormConfig): array
+    {
+        return [
+            'db' => [
+                'default' => 'default',
+                'connections' => [
+                    'default' => [
+                        'driver' => 'mysql',
+                        'host' => $ormConfig['host'],
+                        'port' => $ormConfig['port'],
+                        'database' => $ormConfig['database'],
+                        'username' => $ormConfig['username'],
+                        'password' => $ormConfig['password'],
+                        'charset' => $ormConfig['charset'],
+                        'collation' => $ormConfig['collation'],
+                        'prefix' => $ormConfig['prefix'],
+                        'options' => $ormConfig['options'],
+                    ],
+                ],
+            ],
+            'db.pool' => [
+                'default' => [
+                    'min_connections' => $ormConfig['pool']['min_connections'],
+                    'max_connections' => $ormConfig['pool']['max_connections'],
+                    'connect_timeout' => $ormConfig['pool']['connect_timeout'],
+                    'wait_timeout' => $ormConfig['pool']['wait_timeout'],
+                    'max_idle_time' => $ormConfig['pool']['max_idle_time'],
+                ],
+            ],
+        ];
+    }
+
+    private function attachQueryLogger(ConnectionResolver $resolver): void
+    {
+        $connection = $resolver->connection();
+        if (!method_exists($connection, 'listen')) {
+            error_log('PHAPI ORM MySQL: query logging requested, but connection does not support listen().');
+            return;
+        }
+
+        $connection->listen(static function ($query): void {
+            $sql = '';
+            $bindings = [];
+            $time = null;
+
+            if (is_object($query)) {
+                if (property_exists($query, 'sql')) {
+                    $sql = (string)$query->sql;
+                }
+                if (property_exists($query, 'bindings')) {
+                    $bindings = $query->bindings;
+                }
+                if (property_exists($query, 'time')) {
+                    $time = $query->time;
+                }
+            } elseif (is_array($query)) {
+                $sql = (string)($query['sql'] ?? '');
+                $bindings = $query['bindings'] ?? [];
+                $time = $query['time'] ?? null;
+            }
+
+            $timeValue = $time === null ? 'n/a' : $time . 'ms';
+            $bindingInfo = $bindings === [] ? '' : ' bindings=' . json_encode($bindings);
+            error_log(sprintf('PHAPI ORM query (%s): %s%s', $timeValue, $sql, $bindingInfo));
+        });
+    }
+}

--- a/src/Services/Database.php
+++ b/src/Services/Database.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Services;
+
+use PHAPI\Contracts\DatabaseInterface;
+use PHAPI\Exceptions\DatabaseException;
+
+final class Database implements DatabaseInterface
+{
+    private object $resolver;
+    private bool $debug;
+
+    public function __construct(object $resolver, bool $debug = false)
+    {
+        $this->resolver = $resolver;
+        $this->debug = $debug;
+    }
+
+    public function table(string $table): object
+    {
+        try {
+            return $this->resolver->connection('default')->table($table);
+        } catch (\Throwable $e) {
+            throw $this->wrapException($e, 'table:' . $table, []);
+        }
+    }
+
+    public function select(string $sql, array $bindings = []): array
+    {
+        try {
+            return $this->resolver->connection()->select($sql, $bindings);
+        } catch (\Throwable $e) {
+            throw $this->wrapException($e, $sql, $bindings);
+        }
+    }
+
+    public function statement(string $sql, array $bindings = []): bool
+    {
+        try {
+            return $this->resolver->connection()->statement($sql, $bindings);
+        } catch (\Throwable $e) {
+            throw $this->wrapException($e, $sql, $bindings);
+        }
+    }
+
+    public function transaction(callable $fn)
+    {
+        try {
+            return $this->resolver->connection()->transaction($fn);
+        } catch (\Throwable $e) {
+            throw $this->wrapException($e, 'transaction', []);
+        }
+    }
+
+    public function connection(): object
+    {
+        return $this->resolver->connection();
+    }
+
+    /**
+     * @param \Throwable $exception
+     * @param string|null $sql
+     * @param array<int, mixed> $bindings
+     * @return DatabaseException
+     */
+    private function wrapException(\Throwable $exception, ?string $sql, array $bindings): DatabaseException
+    {
+        $message = 'Database query failed.';
+        if ($this->debug && $sql !== null) {
+            $bindingInfo = $bindings === [] ? '' : ' Bindings: ' . json_encode($bindings);
+            $message = sprintf('Database query failed. SQL: %s%s', $sql, $bindingInfo);
+        }
+
+        return new DatabaseException($message, $exception, $sql, $bindings);
+    }
+}

--- a/tests/OrmMysqlProviderTest.php
+++ b/tests/OrmMysqlProviderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHAPI\Tests;
+
+use Hyperf\DbConnection\ConnectionResolver;
+use PHAPI\Exceptions\ConfigException;
+use PHAPI\PHAPI;
+use PHAPI\Providers\OrmMysqlProvider;
+
+final class OrmMysqlProviderTest extends SwooleTestCase
+{
+    public function testDatabaseServiceUsesResolver(): void
+    {
+        $api = new PHAPI([
+            'runtime' => 'swoole',
+            'providers' => [OrmMysqlProvider::class],
+            'orm' => [
+                'mysql' => [
+                    'database' => 'app',
+                    'username' => 'root',
+                ],
+            ],
+        ]);
+
+        $connection = new FakeConnection();
+        $resolver = new FakeResolver($connection);
+
+        $api->container()->singleton(ConnectionResolver::class, static function () use ($resolver) {
+            return $resolver;
+        });
+
+        $db = $api->database();
+        $tableResult = $db->table('users');
+        $selectResult = $db->select('select * from users where id = ?', [1]);
+        $statementResult = $db->statement('update users set name = ? where id = ?', ['Ada', 1]);
+        $transactionResult = $db->transaction(static fn () => 'ok');
+
+        self::assertSame('users', $connection->lastTable);
+        self::assertSame('users', $tableResult->table);
+        self::assertSame(['select * from users where id = ?', [1]], $connection->lastSelect);
+        self::assertSame([['ok' => true]], $selectResult);
+        self::assertSame(['update users set name = ? where id = ?', ['Ada', 1]], $connection->lastStatement);
+        self::assertTrue($statementResult);
+        self::assertSame(1, $connection->transactions);
+        self::assertSame('ok', $transactionResult);
+        self::assertSame($db, PHAPI::db());
+    }
+
+    public function testProviderValidatesConfig(): void
+    {
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('PHAPI ORM MySQL config requires a database name.');
+
+        new PHAPI([
+            'runtime' => 'swoole',
+            'providers' => [OrmMysqlProvider::class],
+            'orm' => [
+                'mysql' => [
+                    'database' => '',
+                    'username' => '',
+                ],
+            ],
+        ]);
+    }
+}
+
+final class FakeResolver
+{
+    public ?string $lastConnection = null;
+
+    public function __construct(private FakeConnection $connection)
+    {
+    }
+
+    public function connection(?string $name = null): FakeConnection
+    {
+        $this->lastConnection = $name;
+        return $this->connection;
+    }
+}
+
+final class FakeConnection
+{
+    public ?string $lastTable = null;
+    /**
+     * @var array<int, mixed>
+     */
+    public array $lastSelect = [];
+    /**
+     * @var array<int, mixed>
+     */
+    public array $lastStatement = [];
+    public int $transactions = 0;
+
+    public function table(string $table): object
+    {
+        $this->lastTable = $table;
+        return (object)['table' => $table];
+    }
+
+    /**
+     * @param string $sql
+     * @param array<int, mixed> $bindings
+     * @return array<int, array<string, bool>>
+     */
+    public function select(string $sql, array $bindings = []): array
+    {
+        $this->lastSelect = [$sql, $bindings];
+        return [['ok' => true]];
+    }
+
+    /**
+     * @param string $sql
+     * @param array<int, mixed> $bindings
+     * @return bool
+     */
+    public function statement(string $sql, array $bindings = []): bool
+    {
+        $this->lastStatement = [$sql, $bindings];
+        return true;
+    }
+
+    /**
+     * @param callable(): mixed $fn
+     * @return mixed
+     */
+    public function transaction(callable $fn)
+    {
+        $this->transactions++;
+        return $fn();
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an easy-to-discover, model-friendly reference file in consumer projects by copying the shipped `llms.txt` into the project root on Composer install/update. 
- Make the README clear about the generated LLM guide and keep example blocks formatted correctly.

### Description

- Add Composer lifecycle scripts `post-install-cmd` and `post-update-cmd` in `composer.json` that run an inline PHP one-liner to copy `llms.txt` from the package into the consumer project root as `phapi-llms.txt` only if the target does not already exist. 
- Document the generated `phapi-llms.txt` in `README.md` under a new "LLM guide file" section. 
- Move the README LLM note out of an example code block to preserve formatting and clarity.

### Testing

- No automated tests were run as part of this change (no `composer test`, `composer phpstan`, or linter runs were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871ceac59c832c9f5da382331f4600)